### PR TITLE
For your consideration sir.

### DIFF
--- a/OSCeleton/OSCeleton.cpp
+++ b/OSCeleton/OSCeleton.cpp
@@ -35,7 +35,7 @@ char osc_buffer[OUTPUT_BUFFER_SIZE];
 UdpTransmitSocket *transmitSocket;
 
 char tmp[50];
-float jointCoords[3];
+float jointCoords[4];
 
 //Multipliers for coordinate system. This is useful if you use software like animata,
 //that needs OSC messages to use an arbitrary coordinate system.


### PR DESCRIPTION
Building and running on OS X happened to place the userGenerator after the jointCoords in memory, causing the write to jointCoords[3] in jointPos to destroy the userGenerator in memory.
