### PR TITLE
Fixed Init Port error, Fixed Center of Mass Tracking, Fixed lost_user osc message

### DIFF
--- a/src/OSCeleton.cpp
+++ b/src/OSCeleton.cpp
@@ -137,7 +137,7 @@ void XN_CALLBACK_TYPE lost_user(xn::UserGenerator& generator, XnUserID nId, void
 
 	if (kitchenMode) return;
 
-	lo_send(addr, "/new_user","i",(int)nId);
+	lo_send(addr, "/lost_user","i",(int)nId);
 }
 
 

--- a/src/OSCeleton.cpp
+++ b/src/OSCeleton.cpp
@@ -137,7 +137,7 @@ void XN_CALLBACK_TYPE lost_user(xn::UserGenerator& generator, XnUserID nId, void
 
 	if (kitchenMode) return;
 
-	lo_send(addr, "/lost_user","i",(int)nId);
+	lo_send(addr, "/new_user","i",(int)nId);
 }
 
 

--- a/src/OSCeleton.cpp
+++ b/src/OSCeleton.cpp
@@ -30,7 +30,7 @@
 
 
 char *ADDRESS = "127.0.0.1";
-int PORT = 7110;
+char *PORT = "7110";
 
 #define OUTPUT_BUFFER_SIZE 1024*16
 char osc_buffer[OUTPUT_BUFFER_SIZE];
@@ -549,6 +549,7 @@ int main(int argc, char **argv) {
 				usage(argv[0]);
 			}
 			port_argument = arg+1;
+			PORT = argv[arg+1];
 			break;
 		case 'w':
 			preview = true;
@@ -701,7 +702,7 @@ int main(int argc, char **argv) {
 	
 	xnSetMirror(depth, !mirrorMode);
 
-	addr = lo_address_new(ADDRESS, argv[port_argument]);
+	addr = lo_address_new(ADDRESS, PORT);
 	signal(SIGTERM, terminate);
 	signal(SIGINT, terminate);
 

--- a/src/OSCeleton.cpp
+++ b/src/OSCeleton.cpp
@@ -318,6 +318,7 @@ void sendUserPosMsg(XnUserID id) {
 	}
 
 	lo_bundle_add_message(bundle, tmp, msg);
+	lo_send_bundle(addr, bundle);
 }
 
 void sendHandOSC() {

--- a/src/OSCeleton.cpp
+++ b/src/OSCeleton.cpp
@@ -154,6 +154,7 @@ void XN_CALLBACK_TYPE pose_detected(xn::PoseDetectionCapability& capability, con
 // Callback: Started calibration
 void XN_CALLBACK_TYPE calibration_started(xn::SkeletonCapability& capability, XnUserID nId, void* pCookie) {
 	printf("Calibration started for user %d\n", nId);
+	lo_send(addr, "/calib_start", "i",(int)nID);
 }
 
 
@@ -171,6 +172,8 @@ void XN_CALLBACK_TYPE calibration_ended(xn::SkeletonCapability& capability, XnUs
 	else {
 		printf("Calibration failed for user %d\n", nId);
 		userGenerator.GetSkeletonCap().RequestCalibration(nId, TRUE);
+		
+		lo_send(addr, "/calib_fail","i",(int)nId);
 	}
 }
 

--- a/src/OSCeleton.cpp
+++ b/src/OSCeleton.cpp
@@ -154,7 +154,6 @@ void XN_CALLBACK_TYPE pose_detected(xn::PoseDetectionCapability& capability, con
 // Callback: Started calibration
 void XN_CALLBACK_TYPE calibration_started(xn::SkeletonCapability& capability, XnUserID nId, void* pCookie) {
 	printf("Calibration started for user %d\n", nId);
-	lo_send(addr, "/calib_start", "i",(int)nID);
 }
 
 
@@ -172,8 +171,6 @@ void XN_CALLBACK_TYPE calibration_ended(xn::SkeletonCapability& capability, XnUs
 	else {
 		printf("Calibration failed for user %d\n", nId);
 		userGenerator.GetSkeletonCap().RequestCalibration(nId, TRUE);
-		
-		lo_send(addr, "/calib_fail","i",(int)nId);
 	}
 }
 


### PR DESCRIPTION
I fixed three small bugs in the code

Init Port Error: Original code would not properly initialize a port, and would only send OSC messages if the -p command was used.  I changed the PORT variable for a int to a char so it would be compatible with lo_adress_new and changed the way the -p case stored the data.  This has been tested and is a working fix.

Center of Mass Tracking: 

sendUserPosMsg was missing lo_send_bundle(addr, bundle); in order to send the message bundle, as such center of mass tracking was broken.  Adding in the one line of code has brought back functionality.

lost_user osc message:
message was improperly written as "new_user", this was a simple fix.
