### PR TITLE
Added OSC messages /calib_start and /calib_fail

### DIFF
--- a/src/OSCeleton.cpp
+++ b/src/OSCeleton.cpp
@@ -154,6 +154,8 @@ void XN_CALLBACK_TYPE pose_detected(xn::PoseDetectionCapability& capability, con
 // Callback: Started calibration
 void XN_CALLBACK_TYPE calibration_started(xn::SkeletonCapability& capability, XnUserID nId, void* pCookie) {
 	printf("Calibration started for user %d\n", nId);
+	
+	lo_send(addr, "/calib_start","i",(int)nId);
 }
 
 
@@ -171,6 +173,8 @@ void XN_CALLBACK_TYPE calibration_ended(xn::SkeletonCapability& capability, XnUs
 	else {
 		printf("Calibration failed for user %d\n", nId);
 		userGenerator.GetSkeletonCap().RequestCalibration(nId, TRUE);
+		
+		lo_send(addr, "/calib_fail","i",(int)nId);
 	}
 }
 


### PR DESCRIPTION
These additional messages will allow the end user to monitor
calibration of skeletons within their applications rather than within
the terminal

messages /calib_start [user_num] and /calib_fail [user_num]
